### PR TITLE
Add ^WT binding to close/tab the current-buffer

### DIFF
--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -33,6 +33,14 @@
     (elscreen-kill)
     (evil-quit bang)))
 
+(evil-define-command evil-tabs-current-buffer-to-tab ()
+  (let ((nwindows (length (window-list)))
+        (cb (current-buffer)))
+    (when (> nwindows 1)
+      (delete-window)
+      (elscreen-create)
+      (switch-to-buffer cb))))
+
 (evil-ex-define-cmd "tabe[dit]" 'evil-tabs-tabedit)
 (evil-ex-define-cmd "tabclone" 'elscreen-clone)
 (evil-ex-define-cmd "tabc[lose]" 'elscreen-kill)
@@ -47,9 +55,11 @@
 (evil-ex-define-cmd "tabw[ith]" 'elscreen-find-and-goto-by-buffer)
 (evil-ex-define-cmd "q[uit]" 'evil-tab-sensitive-quit)
 
+
 (evil-define-key 'normal evil-tabs-mode-map
   "gt" 'elscreen-next
-  "gT" 'elscreen-previous)
+  "gT" 'elscreen-previous
+  "T" 'evil-tabs-current-buffer-to-tab)
 
 ;;;###autoload
 (define-minor-mode evil-tabs-mode

--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -55,7 +55,6 @@
 (evil-ex-define-cmd "tabw[ith]" 'elscreen-find-and-goto-by-buffer)
 (evil-ex-define-cmd "q[uit]" 'evil-tab-sensitive-quit)
 
-
 (evil-define-key 'normal evil-tabs-mode-map
   "gt" 'elscreen-next
   "gT" 'elscreen-previous


### PR DESCRIPTION
This mimicks Vim's behaviour to open the current-buffer on its own tab
(and close it) with ^WT. If there's only one window on the current tab,
nothing happens (as in Vim). This closes #3.