### PR TITLE
Make #gt jump to the `#`-nth elscreen tab

### DIFF
--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -33,6 +33,11 @@
     (elscreen-kill)
     (evil-quit bang)))
 
+(evil-define-motion evil-tabs-goto-tab (&optional count)
+  (if count
+     (elscreen-goto (- count 1))
+     (elscreen-next)))
+
 (evil-ex-define-cmd "tabe[dit]" 'evil-tabs-tabedit)
 (evil-ex-define-cmd "tabclone" 'elscreen-clone)
 (evil-ex-define-cmd "tabc[lose]" 'elscreen-kill)
@@ -48,7 +53,7 @@
 (evil-ex-define-cmd "q[uit]" 'evil-tab-sensitive-quit)
 
 (evil-define-key 'normal evil-tabs-mode-map
-  "gt" 'elscreen-next
+  "gt" 'evil-tabs-goto-tab
   "gT" 'elscreen-previous)
 
 ;;;###autoload


### PR DESCRIPTION
This is a little confusing, because on Vim tabs are 1-indexed, while
elscreen tabs are 0-indexed. However, typing 0gt on `evil-mode` passed
the `count` argument as `nil`, rather than `0`. This makes it hard (with
my lack of Emacs Lisp knowledge) to make 0gt work properly and make the
feature use 0-indexing on emacs - tabs are numbered by default, so this
would obviously be better.

Mimicking the Vim behaviour is not so bad, though.

This closes #8.