### PR TITLE
Fix relative directories with :tabe[dit].

### DIFF
--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -23,8 +23,7 @@
 
 (evil-define-command evil-tabs-tabedit (file)
   (interactive "<f>")
-  (elscreen-create)
-  (find-file file))
+  (elscreen-find-file file))
 
 (evil-define-command evil-tab-sensitive-quit (&optional bang)
   :repeat nil


### PR DESCRIPTION
As discussed in #13, this replaces the calls to `elscreen-create` and `find-file` with `elscreen-find-file` so `default-directory` is respected.
