### PR TITLE
Make `:q` and `:x` behave consistently with vim. Fixes #16.

### DIFF
--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -25,7 +25,7 @@
   (if (and (one-window-p) (not (elscreen-one-screen-p)))
     ;; 1. If there is one split and more than one screen, use elscreen-kill.
     (elscreen-kill)
-    ;; 2. Otherwise, use evil-quit (i.e.: multiple splits, one screen; one split,
+    ;; 2. Otherwise, use evil-quit (i.e. multiple splits, one screen; one split,
     ;; one screen).
     (evil-quit bang)))
 

--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -38,6 +38,12 @@
   (interactive "<!>")
   (evil-tabs--quit))
 
+(evil-define-command evil-tabs-sensitive-save-modified-and-quit (file &optional bang)
+  :repeat nil
+  (interactive "<f><!>")
+  (evil-write nil nil nil file bang)
+  (evil-tabs--quit))
+
 (evil-define-command evil-tabs-current-buffer-to-tab ()
   (let ((nwindows (length (window-list)))
         (cb (current-buffer)))
@@ -64,6 +70,8 @@
 (evil-ex-define-cmd "tabs[elect]" 'elscreen-select-and-goto)
 (evil-ex-define-cmd "tabw[ith]" 'elscreen-find-and-goto-by-buffer)
 (evil-ex-define-cmd "q[uit]" 'evil-tab-sensitive-quit)
+(evil-ex-define-cmd "x[it]" 'evil-tabs-save-modified-and-quit)
+(evil-ex-define-cmd "exi[t]" 'evil-tabs-save-modified-and-quit)
 
 (evil-define-key 'normal evil-tabs-mode-map
   "gt" 'elscreen-next

--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -33,7 +33,7 @@
   (interactive "<f>")
   (elscreen-find-file file))
 
-(evil-define-command evil-tab-sensitive-quit (&optional bang)
+(evil-define-command evil-tabs-sensitive-quit (&optional bang)
   :repeat nil
   (interactive "<!>")
   (evil-tabs--quit))
@@ -69,7 +69,7 @@
 (evil-ex-define-cmd "tabr[ename]" 'elscreen-screen-nickname)
 (evil-ex-define-cmd "tabs[elect]" 'elscreen-select-and-goto)
 (evil-ex-define-cmd "tabw[ith]" 'elscreen-find-and-goto-by-buffer)
-(evil-ex-define-cmd "q[uit]" 'evil-tab-sensitive-quit)
+(evil-ex-define-cmd "q[uit]" 'evil-tabs-sensitive-quit)
 (evil-ex-define-cmd "x[it]" 'evil-tabs-save-modified-and-quit)
 (evil-ex-define-cmd "exi[t]" 'evil-tabs-save-modified-and-quit)
 

--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -70,8 +70,8 @@
 (evil-ex-define-cmd "tabs[elect]" 'elscreen-select-and-goto)
 (evil-ex-define-cmd "tabw[ith]" 'elscreen-find-and-goto-by-buffer)
 (evil-ex-define-cmd "q[uit]" 'evil-tabs-sensitive-quit)
-(evil-ex-define-cmd "x[it]" 'evil-tabs-save-modified-and-quit)
-(evil-ex-define-cmd "exi[t]" 'evil-tabs-save-modified-and-quit)
+(evil-ex-define-cmd "x[it]" 'evil-tabs-sensitive-save-modified-and-quit)
+(evil-ex-define-cmd "exi[t]" 'evil-tabs-sensitive-save-modified-and-quit)
 
 (evil-define-key 'normal evil-tabs-mode-map
   "gt" 'elscreen-next

--- a/evil-tabs.el
+++ b/evil-tabs.el
@@ -21,6 +21,14 @@
 (defvar evil-tabs-mode-map (make-sparse-keymap)
   "Evil-tabs-mode's keymap.")
 
+(evil-define-command evil-tabs--quit (&optional bang)
+  (if (and (one-window-p) (not (elscreen-one-screen-p)))
+    ;; 1. If there is one split and more than one screen, use elscreen-kill.
+    (elscreen-kill)
+    ;; 2. Otherwise, use evil-quit (i.e.: multiple splits, one screen; one split,
+    ;; one screen).
+    (evil-quit bang)))
+
 (evil-define-command evil-tabs-tabedit (file)
   (interactive "<f>")
   (elscreen-find-file file))
@@ -28,9 +36,7 @@
 (evil-define-command evil-tab-sensitive-quit (&optional bang)
   :repeat nil
   (interactive "<!>")
-  (if (> (length (elscreen-get-screen-list)) 1)
-    (elscreen-kill)
-    (evil-quit bang)))
+  (evil-tabs--quit))
 
 (evil-define-command evil-tabs-current-buffer-to-tab ()
   (let ((nwindows (length (window-list)))


### PR DESCRIPTION
Currently, quitting with `:x` or `:q` results in unexpected behavior: if there are two splits on a specific screen (tab) and there is more than one screen, `:q:` or `:x` will kill the whole screen. This is inconsistent with the way vim works.

This pull request fixes the behavior of both `:q` and `:x`. Previously, `evil-tabs` did not handle `:x` at all.
This also changes `evil-tab-sensitive-quit` to `evil-tabs-sensitive-quit` (plural "tabs") for naming consistency with the rest of the file.
